### PR TITLE
Change BLAS implementation from accelerate to netlib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 rand = "0.7.3"
 rand_distr = "0.2.2"
 blas = "0.20.0"
-blas-src = { version = "0.6", features = ["accelerate"] }
+blas-src = { version = "0.6", features = ["netlib"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-apple-darwin"]


### PR DESCRIPTION
Currently, the BLAS implementation defaults to accelerate, the Apple
one, which is macOS only. On top of preventing non macOS user to build
the code as-is, it also causes the CI to fail.

Netlib is the "vanilla" BLAS implementation. Not very efficient, but
should work on the highest number of platforms.